### PR TITLE
Checkpoint8

### DIFF
--- a/bin/psrlint
+++ b/bin/psrlint
@@ -19,13 +19,22 @@ $cmd->option('f')
     ->default(false)
     ->describedAs('Fix files errors');
 
-$result = hpl\run($cmd['path'], $cmd['fix']);
+$cmd->option('rf')
+    ->aka('reportFormat')
+    ->must(function($format) {
+            $formats = array('text', 'json', 'yaml');
+            return in_array($format, $formats);
+        })
+    ->describedAs('Report format: text, json, yaml');
+
+$result = hpl\run($cmd['path'],
+                  ['fix' => $cmd['fix'],
+                   'format' => $cmd['reportFormat'],
+                  ]);
 
 if (!empty($result)) {
     $exitCode = 1;
-    foreach ($result as $key => $item) {
-        hpl\printResult($item, $key);
-    }
+    hpl\printResult($result);
 } else {
     $exitCode = 0;
     echo "\nAll files are correct.\n";

--- a/src/NodeVisitor.php
+++ b/src/NodeVisitor.php
@@ -32,7 +32,7 @@ class NodeVisitor extends NodeVisitorAbstract
             if ($result) {
                 if ($this->fix) {
                     $node->name = fixFuncName($node->name);
-                    $result['errorType'] = 'fixed';
+                    $result['error type'] = 'fixed';
                     $result['name'] = $result['name'].' -> '.$node->name;
                 }
                 $this->errors[] = $result;
@@ -44,7 +44,7 @@ class NodeVisitor extends NodeVisitorAbstract
             if ($result) {
                 if ($this->fix) {
                     $node->name = fixVarName($node->name);
-                    $result['errorType'] = 'fixed';
+                    $result['error type'] = 'fixed';
                     $result['name'] = $result['name'].' -> '.$node->name;
                 }
                 $this->errors[] = $result;

--- a/src/io.php
+++ b/src/io.php
@@ -4,24 +4,87 @@ namespace HexletPsrLinter;
 
 use Lijinma\Color;
 
-function printResult(array $errors, $filename = '')
+function printResult($result)
 {
-    echo PHP_EOL.Color::WHITE.$filename.PHP_EOL;
-    $counter = 0;
-    foreach ($errors as $err) {
-        echo Color::GREEN.$err['startLine']."\t".$err['name']."\t\t";
-        echo Color::YELLOW.$err['errorType'].PHP_EOL;
-        echo Color::LIGHT_GRAY.$err['descr'].PHP_EOL;
-        if ($err['errorType'] !== 'fixed') {
-            ++$counter;
+    echo $result;
+}
+
+function makeReport(array $result, $format)
+{
+    $report = '';
+    switch ($format) {
+       case 'text':
+          foreach ($result as $filename => $errors) {
+              $report .= $filename . PHP_EOL;
+              $counter = 0;
+              foreach ($errors as $err) {
+                  $report .= $err['line']."\t".$err['name']."\t\t";
+                  $report .= $err['error type'] . PHP_EOL;
+                  $report .= $err['description'] . PHP_EOL;
+                  if ($err['error type'] !== 'fixed') {
+                      ++$counter;
+                  }
+              }
+              if ($counter) {
+                  $report .= $counter.' problems';
+              } else {
+                  $report .= "\tok";
+              }
+              $report .= PHP_EOL . '---------------------------------------------' . PHP_EOL;
+          }
+          break;
+
+      case 'json':
+          foreach ($result as $filename => $errors) {
+              $report .= "{". PHP_EOL;
+              $report .= "\t\"" . $filename . "\":[" . PHP_EOL;
+              foreach ($errors as $err) {
+                  $report .= "\t{" . PHP_EOL;
+                  $report .= "\t\t\"error type\" : \"" . $err['error type'] . "\",\n";
+                  $report .= "\t\t\"description\" : \"" . $err['description'] . "\",\n";
+                  $report .= "\t\t\"line\" : \"" . $err['line'] . "\",\n";
+                  $report .= "\t\t\"name\" : \"" . $err['name'] . "\"\n";
+                  $report .= "\t}," . PHP_EOL;
+              }
+              $report .= "]}\n";
+          }
+          break;
+
+      case 'yaml':
+          foreach ($result as $filename => $errors) {
+              $report .= $filename . ":" . PHP_EOL;
+              foreach ($errors as $err) {
+                  $report .= "  - error type: " . $err['error type'] . "\n";
+                  $report .= "    description: " . $err['description']. "\n";
+                  $report .= "    line: " . $err['line'] . "\n";
+                  $report .= "    name: " . $err['name'] . "\n";
+              }
+          }
+          break;
+
+      default:  // CLI
+        foreach ($result as $filename => $errors) {
+            $report .= PHP_EOL.Color::WHITE.$filename.PHP_EOL;
+            $counter = 0;
+            foreach ($errors as $err) {
+                $report .= Color::GREEN.$err['line']."\t".$err['name']."\t\t";
+                $report .= Color::YELLOW.$err['error type'].PHP_EOL;
+                $report .= Color::LIGHT_GRAY.$err['description'].PHP_EOL;
+                if ($err['error type'] !== 'fixed') {
+                    ++$counter;
+                }
+            }
+            if ($counter) {
+                $report .= Color::LIGHT_RED.$counter.' problems';
+            } else {
+                $report .= Color::GREEN."\tok";
+            }
+            $report .= PHP_EOL.'----------------------------------------------------'.PHP_EOL;
         }
+        break;
     }
-    if ($counter) {
-        echo Color::LIGHT_RED.$counter.' problems';
-    } else {
-        echo Color::GREEN."\tok";
-    }
-    echo PHP_EOL.'----------------------------------------------------'.PHP_EOL;
+
+    return $report;
 }
 
 function checkFileErrors($filename, $fix = false)
@@ -31,25 +94,25 @@ function checkFileErrors($filename, $fix = false)
         $file = new \SplFileInfo($filename);
 
         if ($file->getExtension() !== 'php') {
-            $error = ['descr' => 'File must have php extension',
-                      'startLine' => '-',
-                      'name' => $filename,
-                      'errorType' => 'error',
+            $error = ['description' => 'File must have php extension',
+                             'line' => '-',
+                             'name' => $filename,
+                       'error type' => 'error',
                      ];
         } else {
             if ($fix && !is_writable($filename)) {
-                $error = ['descr' => 'Error writing to file.',
-                          'startLine' => '-',
-                          'name' => $filename,
-                          'errorType' => 'error',
+                $error = ['description' => 'Error writing to file.',
+                                 'line' => '-',
+                                 'name' => $filename,
+                           'error type' => 'error',
                        ];
             }
         }
     } else {
-        $error = ['descr' => "File or directory doesn't exist",
-                  'startLine' => '-',
-                  'name' => $filename,
-                  'errorType' => 'error',
+        $error = ['description' => "File or directory doesn't exist",
+                         'line' => '-',
+                         'name' => $filename,
+                   'error type' => 'error',
                  ];
     }
 

--- a/src/io.php
+++ b/src/io.php
@@ -35,19 +35,7 @@ function makeReport(array $result, $format)
             break;
 
         case 'json':
-            foreach ($result as $filename => $errors) {
-                $report .= "{". PHP_EOL;
-                $report .= "\t\"" . $filename . "\":[" . PHP_EOL;
-                foreach ($errors as $err) {
-                    $report .= "\t{" . PHP_EOL;
-                    $report .= "\t\t\"error type\" : \"" . $err['error type'] . "\",\n";
-                    $report .= "\t\t\"description\" : \"" . $err['description'] . "\",\n";
-                    $report .= "\t\t\"line\" : \"" . $err['line'] . "\",\n";
-                    $report .= "\t\t\"name\" : \"" . $err['name'] . "\"\n";
-                    $report .= "\t}," . PHP_EOL;
-                }
-                $report .= "]}\n";
-            }
+            $report .= json_encode($result, JSON_PRETTY_PRINT);
             break;
 
         case 'yaml':

--- a/src/io.php
+++ b/src/io.php
@@ -13,75 +13,75 @@ function makeReport(array $result, $format)
 {
     $report = '';
     switch ($format) {
-       case 'text':
-          foreach ($result as $filename => $errors) {
-              $report .= $filename . PHP_EOL;
-              $counter = 0;
-              foreach ($errors as $err) {
-                  $report .= $err['line']."\t".$err['name']."\t\t";
-                  $report .= $err['error type'] . PHP_EOL;
-                  $report .= $err['description'] . PHP_EOL;
-                  if ($err['error type'] !== 'fixed') {
-                      ++$counter;
-                  }
-              }
-              if ($counter) {
-                  $report .= $counter.' problems';
-              } else {
-                  $report .= "\tok";
-              }
-              $report .= PHP_EOL . '---------------------------------------------' . PHP_EOL;
-          }
-          break;
+        case 'text':
+            foreach ($result as $filename => $errors) {
+                $report .= $filename . PHP_EOL;
+                $counter = 0;
+                foreach ($errors as $err) {
+                    $report .= $err['line']."\t".$err['name']."\t\t";
+                    $report .= $err['error type'] . PHP_EOL;
+                    $report .= $err['description'] . PHP_EOL;
+                    if ($err['error type'] !== 'fixed') {
+                        ++$counter;
+                    }
+                }
+                if ($counter) {
+                    $report .= $counter.' problems';
+                } else {
+                    $report .= "\tok";
+                }
+                $report .= PHP_EOL . '---------------------------------------------' . PHP_EOL;
+            }
+            break;
 
-      case 'json':
-          foreach ($result as $filename => $errors) {
-              $report .= "{". PHP_EOL;
-              $report .= "\t\"" . $filename . "\":[" . PHP_EOL;
-              foreach ($errors as $err) {
-                  $report .= "\t{" . PHP_EOL;
-                  $report .= "\t\t\"error type\" : \"" . $err['error type'] . "\",\n";
-                  $report .= "\t\t\"description\" : \"" . $err['description'] . "\",\n";
-                  $report .= "\t\t\"line\" : \"" . $err['line'] . "\",\n";
-                  $report .= "\t\t\"name\" : \"" . $err['name'] . "\"\n";
-                  $report .= "\t}," . PHP_EOL;
-              }
-              $report .= "]}\n";
-          }
-          break;
+        case 'json':
+            foreach ($result as $filename => $errors) {
+                $report .= "{". PHP_EOL;
+                $report .= "\t\"" . $filename . "\":[" . PHP_EOL;
+                foreach ($errors as $err) {
+                    $report .= "\t{" . PHP_EOL;
+                    $report .= "\t\t\"error type\" : \"" . $err['error type'] . "\",\n";
+                    $report .= "\t\t\"description\" : \"" . $err['description'] . "\",\n";
+                    $report .= "\t\t\"line\" : \"" . $err['line'] . "\",\n";
+                    $report .= "\t\t\"name\" : \"" . $err['name'] . "\"\n";
+                    $report .= "\t}," . PHP_EOL;
+                }
+                $report .= "]}\n";
+            }
+            break;
 
-      case 'yaml':
-          foreach ($result as $filename => $errors) {
-              $report .= $filename . ":" . PHP_EOL;
-              foreach ($errors as $err) {
-                  $report .= "  - error type: " . $err['error type'] . "\n";
-                  $report .= "    description: " . $err['description']. "\n";
-                  $report .= "    line: " . $err['line'] . "\n";
-                  $report .= "    name: " . $err['name'] . "\n";
-              }
-          }
-          break;
-
-      default:  // CLI
-        foreach ($result as $filename => $errors) {
-            $report .= PHP_EOL.Color::WHITE.$filename.PHP_EOL;
-            $counter = 0;
-            foreach ($errors as $err) {
-                $report .= Color::GREEN.$err['line']."\t".$err['name']."\t\t";
-                $report .= Color::YELLOW.$err['error type'].PHP_EOL;
-                $report .= Color::LIGHT_GRAY.$err['description'].PHP_EOL;
-                if ($err['error type'] !== 'fixed') {
-                    ++$counter;
+        case 'yaml':
+            foreach ($result as $filename => $errors) {
+                $report .= $filename . ":" . PHP_EOL;
+                foreach ($errors as $err) {
+                    $report .= "  - error type: " . $err['error type'] . "\n";
+                    $report .= "    description: " . $err['description']. "\n";
+                    $report .= "    line: " . $err['line'] . "\n";
+                    $report .= "    name: " . $err['name'] . "\n";
                 }
             }
-            if ($counter) {
-                $report .= Color::LIGHT_RED.$counter.' problems';
-            } else {
-                $report .= Color::GREEN."\tok";
+            break;
+
+        default:  // CLI
+            foreach ($result as $filename => $errors) {
+                $report .= PHP_EOL.Color::WHITE.$filename.PHP_EOL;
+                $counter = 0;
+                foreach ($errors as $err) {
+                    $report .= Color::GREEN.$err['line']."\t".$err['name']."\t\t";
+                    $report .= Color::YELLOW.$err['error type'].PHP_EOL;
+                    $report .= Color::LIGHT_GRAY.$err['description'].PHP_EOL;
+                    if ($err['error type'] !== 'fixed') {
+                        ++$counter;
+                    }
+                }
+                if ($counter) {
+                    $report .= Color::LIGHT_RED.$counter.' problems';
+                } else {
+                    $report .= Color::GREEN."\tok";
+                }
+                $report .= PHP_EOL.'----------------------------------------------------'.PHP_EOL;
             }
-            $report .= PHP_EOL.'----------------------------------------------------'.PHP_EOL;
-        }
-        break;
+            break;
     }
 
     return $report;

--- a/src/linter.php
+++ b/src/linter.php
@@ -17,16 +17,18 @@ function linter($code, $fix = false)
 
         return $traverser->traverse($stmts);
     } catch (Error $e) {
-        return [[['descr' => $e->getMessage()." \nLinter was stopped.",
-                       'name' => '-',
-                  'startLine' => '0',
-                  'errorType' => 'parse error',
+        return [[['description' => $e->getMessage()." \nLinter was stopped.",
+                         'name' => '-',
+                         'line' => '0',
+                   'error type' => 'parse error',
                ]], $code];
     }
 }
 
-function run($path, $fix = false)
+function run($path, array $params)
 {
+    isset($params['fix']) ? $fix = $params['fix'] : $fix = false;
+
     if (is_dir($path)) {
         $files = readDir($path);
     } else {
@@ -50,6 +52,8 @@ function run($path, $fix = false)
             $result[$file] = [$errors];
         }
     }
+
+    $result = makeReport($result, $params['format']);
 
     return $result;
 }

--- a/src/rules/function.php
+++ b/src/rules/function.php
@@ -34,12 +34,17 @@ function checkFuncName($func)
         return false;
     }
 
+    return returnErrorsInFuncName($func);
+}
+
+function returnErrorsInFuncName($func)
+{
     $startLine = $func->getAttributes();
 
-    return ['descr' => 'Function name should be written in camelCase style',
-                 'name' => $func->name,
-            'startLine' => $startLine['startLine'],
-            'errorType' => 'warning',
+    return ['description' => 'Function name should be written in camelCase style',
+                   'name' => $func->name,
+                   'line' => $startLine['startLine'],
+             'error type' => 'warning',
            ];
 }
 

--- a/src/rules/sideeffect.php
+++ b/src/rules/sideeffect.php
@@ -29,12 +29,12 @@ function hasSideEffectAndDeclaration(array $nodes)
 function checkSideEffect(array $nodes)
 {
     if (hasSideEffectAndDeclaration($nodes)) {
-        return ['descr' => 'A file SHOULD declare new symbols (classes, functions, constants, etc.)
+        return ['description' => 'A file SHOULD declare new symbols (classes, functions, constants, etc.)
 and cause no other side effects, or it SHOULD execute logic with side effects,
 but SHOULD NOT do both.',
-                   'name' => '-',
-              'startLine' => '1',
-              'errorType' => 'warning',
+                       'name' => '-',
+                       'line' => 1,
+                 'error type' => 'warning',
              ];
     };
 

--- a/src/rules/var.php
+++ b/src/rules/var.php
@@ -20,10 +20,10 @@ function returnErrorsInVarName($var)
 {
     $startLine = $var->getAttributes();
 
-    return  ['descr' => 'Variable must be written in camelCase style.',
-             'name' => $var->name,
-             'startLine' => $startLine['startLine'],
-             'errorType' => 'warning',
+    return  ['description' => 'Variable must be written in camelCase style.',
+                    'name' => $var->name,
+                    'line' => $startLine['startLine'],
+              'error type' => 'warning',
             ];
 }
 

--- a/tests/CheckFileTest.php
+++ b/tests/CheckFileTest.php
@@ -20,9 +20,9 @@ class CheckFileTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(checkFileErrors($this->test1));
 
         $result = checkFileErrors($this->test2);
-        $this->assertEquals("File or directory doesn't exist", $result['descr']);
+        $this->assertEquals("File or directory doesn't exist", $result['description']);
 
         $result = checkFileErrors($this->test3);
-        $this->assertEquals('File must have php extension', $result['descr']);
+        $this->assertEquals('File must have php extension', $result['description']);
     }
 }

--- a/tests/MakeReportTest.php
+++ b/tests/MakeReportTest.php
@@ -11,7 +11,7 @@ class MakeReportTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->file = './tests/fixtures/report/test.php';
+        $this->file = 'tests/fixtures/report/test.php';
         $this->text = file_get_contents('tests/fixtures/report/report.txt');
         $this->json = file_get_contents('tests/fixtures/report/report.json');
         $this->yaml = file_get_contents('tests/fixtures/report/report.yml');
@@ -27,7 +27,7 @@ class MakeReportTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($text, $this->text);
 
         $json = makeReport($result, 'json');
-        $this->assertEquals($json, $this->json);
+        $this->assertEquals($json . "\n", $this->json);
 
         $yaml = makeReport($result, 'yaml');
         $this->assertEquals($yaml, $this->yaml);

--- a/tests/MakeReportTest.php
+++ b/tests/MakeReportTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace HexletPsrLinter;
+
+class MakeReportTest extends \PHPUnit_Framework_TestCase
+{
+    private $file;
+    private $text;
+    private $json;
+    private $yaml;
+
+    public function setUp()
+    {
+        $this->file = './tests/fixtures/report/test.php';
+        $this->text = file_get_contents('tests/fixtures/report/report.txt');
+        $this->json = file_get_contents('tests/fixtures/report/report.json');
+        $this->yaml = file_get_contents('tests/fixtures/report/report.yml');
+    }
+
+    public function testMakeReport()
+    {
+        $result = [];
+        list($linterErrors, $code) = linter(file_get_contents($this->file), false);
+        $result[$this->file] = $linterErrors;
+
+        $text = makeReport($result, 'text');
+        $this->assertEquals($text, $this->text);
+
+        $json = makeReport($result, 'json');
+        $this->assertEquals($json, $this->json);
+
+        $yaml = makeReport($result, 'yaml');
+        $this->assertEquals($yaml, $this->yaml);
+
+    }
+}

--- a/tests/MakeReportTest.php
+++ b/tests/MakeReportTest.php
@@ -31,6 +31,5 @@ class MakeReportTest extends \PHPUnit_Framework_TestCase
 
         $yaml = makeReport($result, 'yaml');
         $this->assertEquals($yaml, $this->yaml);
-
     }
 }

--- a/tests/fixtures/report/report.json
+++ b/tests/fixtures/report/report.json
@@ -1,0 +1,35 @@
+{
+	"./tests/fixtures/report/test.php":[
+	{
+		"error type" : "warning",
+		"description" : "A file SHOULD declare new symbols (classes, functions, constants, etc.)
+and cause no other side effects, or it SHOULD execute logic with side effects,
+but SHOULD NOT do both.",
+		"line" : "1",
+		"name" : "-"
+	},
+	{
+		"error type" : "warning",
+		"description" : "Variable must be written in camelCase style.",
+		"line" : "7",
+		"name" : "var_name"
+	},
+	{
+		"error type" : "warning",
+		"description" : "Variable must be written in camelCase style.",
+		"line" : "9",
+		"name" : "VarName3"
+	},
+	{
+		"error type" : "warning",
+		"description" : "Function name should be written in camelCase style",
+		"line" : "5",
+		"name" : "WrongFunc"
+	},
+	{
+		"error type" : "warning",
+		"description" : "Function name should be written in camelCase style",
+		"line" : "24",
+		"name" : "Wrong_Func2"
+	},
+]}

--- a/tests/fixtures/report/report.json
+++ b/tests/fixtures/report/report.json
@@ -1,35 +1,34 @@
 {
-	"./tests/fixtures/report/test.php":[
-	{
-		"error type" : "warning",
-		"description" : "A file SHOULD declare new symbols (classes, functions, constants, etc.)
-and cause no other side effects, or it SHOULD execute logic with side effects,
-but SHOULD NOT do both.",
-		"line" : "1",
-		"name" : "-"
-	},
-	{
-		"error type" : "warning",
-		"description" : "Variable must be written in camelCase style.",
-		"line" : "7",
-		"name" : "var_name"
-	},
-	{
-		"error type" : "warning",
-		"description" : "Variable must be written in camelCase style.",
-		"line" : "9",
-		"name" : "VarName3"
-	},
-	{
-		"error type" : "warning",
-		"description" : "Function name should be written in camelCase style",
-		"line" : "5",
-		"name" : "WrongFunc"
-	},
-	{
-		"error type" : "warning",
-		"description" : "Function name should be written in camelCase style",
-		"line" : "24",
-		"name" : "Wrong_Func2"
-	},
-]}
+    "tests\/fixtures\/report\/test.php": [
+        {
+            "description": "A file SHOULD declare new symbols (classes, functions, constants, etc.)\nand cause no other side effects, or it SHOULD execute logic with side effects,\nbut SHOULD NOT do both.",
+            "name": "-",
+            "line": 1,
+            "error type": "warning"
+        },
+        {
+            "description": "Variable must be written in camelCase style.",
+            "name": "var_name",
+            "line": 7,
+            "error type": "warning"
+        },
+        {
+            "description": "Variable must be written in camelCase style.",
+            "name": "VarName3",
+            "line": 9,
+            "error type": "warning"
+        },
+        {
+            "description": "Function name should be written in camelCase style",
+            "name": "WrongFunc",
+            "line": 5,
+            "error type": "warning"
+        },
+        {
+            "description": "Function name should be written in camelCase style",
+            "name": "Wrong_Func2",
+            "line": 24,
+            "error type": "warning"
+        }
+    ]
+}

--- a/tests/fixtures/report/report.txt
+++ b/tests/fixtures/report/report.txt
@@ -1,0 +1,15 @@
+./tests/fixtures/report/test.php
+1	-		warning
+A file SHOULD declare new symbols (classes, functions, constants, etc.)
+and cause no other side effects, or it SHOULD execute logic with side effects,
+but SHOULD NOT do both.
+7	var_name		warning
+Variable must be written in camelCase style.
+9	VarName3		warning
+Variable must be written in camelCase style.
+5	WrongFunc		warning
+Function name should be written in camelCase style
+24	Wrong_Func2		warning
+Function name should be written in camelCase style
+5 problems
+---------------------------------------------

--- a/tests/fixtures/report/report.txt
+++ b/tests/fixtures/report/report.txt
@@ -1,4 +1,4 @@
-./tests/fixtures/report/test.php
+tests/fixtures/report/test.php
 1	-		warning
 A file SHOULD declare new symbols (classes, functions, constants, etc.)
 and cause no other side effects, or it SHOULD execute logic with side effects,

--- a/tests/fixtures/report/report.yml
+++ b/tests/fixtures/report/report.yml
@@ -1,0 +1,23 @@
+./tests/fixtures/report/test.php:
+  - error type: warning
+    description: A file SHOULD declare new symbols (classes, functions, constants, etc.)
+and cause no other side effects, or it SHOULD execute logic with side effects,
+but SHOULD NOT do both.
+    line: 1
+    name: -
+  - error type: warning
+    description: Variable must be written in camelCase style.
+    line: 7
+    name: var_name
+  - error type: warning
+    description: Variable must be written in camelCase style.
+    line: 9
+    name: VarName3
+  - error type: warning
+    description: Function name should be written in camelCase style
+    line: 5
+    name: WrongFunc
+  - error type: warning
+    description: Function name should be written in camelCase style
+    line: 24
+    name: Wrong_Func2

--- a/tests/fixtures/report/report.yml
+++ b/tests/fixtures/report/report.yml
@@ -1,4 +1,4 @@
-./tests/fixtures/report/test.php:
+tests/fixtures/report/test.php:
   - error type: warning
     description: A file SHOULD declare new symbols (classes, functions, constants, etc.)
 and cause no other side effects, or it SHOULD execute logic with side effects,

--- a/tests/fixtures/report/test.php
+++ b/tests/fixtures/report/test.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace HexletPsrLinter;
+
+function WrongFunc()
+{
+    $var_name = 0;
+    $varName2 = 0;
+    $VarName3 = 0;
+    $varname4 = 0;
+}
+
+function foo()
+{
+    return 'bar';
+}
+
+class ClassName
+{
+    public function __construct()
+    {
+    }
+
+    public function Wrong_Func2()
+    {
+    }
+}
+
+foo();


### PR DESCRIPTION
8) Реализованная возможность менять формат отчета, помимо стандартного text добавить так же json/yml.

@fox echo "\nAll files are correct.\n";
[7:36]  вот это в bin
[7:37]  а если я попрошу вернуть json, то вот эта строчка выше вернет текст который ни разу не json и мой код сломается
[7:37]  foreach ($result as $filename => $errors) { нужно заменить на array_map + implode
[7:37]  никаких конкатенаций
[7:38]  и в целом, репортеры должны быть полиморфными сущностями и тогда будет соблюдаться принцип https://en.wikipedia.org/wiki/Open/closed_principle
[7:38]  и у вас появится ооп :wink:
[7:38]  а сейчас это страшная функция на 150 строк
